### PR TITLE
resolve mistakes global.css

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -1,7 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Hind:wght@600;&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
-
 
 @import './global.header-nav.css';
 
@@ -18,35 +16,18 @@
   --gray-color5: #707070;
   --font-primary: 'Poppins';
   --font-secondary: 'Hind';
-  scroll-behavior: smooth;
 }
 
 body {
   font-family: var(--font-primary), Helvetica, Arial, Poppins, sans-serif;
-  font-family: "Poppins", sans-serif;
   color: var(--text);
+  scroll-behavior: smooth;
 }
 
 .container {
   max-width: 1200px;
   margin: 0 auto;
   padding: 0 15px;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-ul {
-  padding: 0;
-  margin: 0;
-}
-
-ul {
-  list-style: none;
 }
 
 img {

--- a/css/global.css
+++ b/css/global.css
@@ -19,7 +19,7 @@
 }
 
 body {
-  font-family: var(--font-primary), Helvetica, Arial, Poppins, sans-serif;
+  font-family: var(--font-primary), Helvetica, Arial, system-ui, -apple-system, sans-serif;
   color: var(--text);
   scroll-behavior: smooth;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style Changes**
	- Removed duplicate import for the 'Poppins' font.
	- Added import for the 'Hind' font.
	- Updated the `scroll-behavior` property to apply to the `body` instead of `:root`.
	- Simplified `font-family` in the `body` selector to include additional fallback fonts.
	- Removed padding and margin resets for headings and paragraphs, along with list style resets for unordered lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->